### PR TITLE
Verifiable credentials

### DIFF
--- a/verifiable_credential/fractal_id.json-ld
+++ b/verifiable_credential/fractal_id.json-ld
@@ -26,6 +26,10 @@
         "currency": "xsd:string",
         "verified": "xsd:boolean"
       }
-    }
+    },
+    "identification_document_front_file": "xsd:string",
+    "identification_document_back_file": "xsd:string",
+    "identification_document_selfie_file": "xsd:string",
+    "residential_address_proof_file": "xsd:string",
   }
 }

--- a/verifiable_credential/fractal_id.json-ld
+++ b/verifiable_credential/fractal_id.json-ld
@@ -19,7 +19,7 @@
     "identification_document_date_of_issue": "xsd:date",
     "identification_document_date_of_expiry": "xsd:date",
     "wallets": {
-      "@id": "https://raw.githubusercontent.com/trustfractal/claim-schemas/master/verifiable_credential/fractal_id.json-ld#wallets",
+      "@id": "https://raw.githubusercontent.com/trustfractal/claim-schemas/master/fractal_id.json-ld#wallets",
       "@context": {
         "@protected": true,
         "address": "xsd:string",

--- a/verifiable_credential/fractal_id.json-ld
+++ b/verifiable_credential/fractal_id.json-ld
@@ -30,6 +30,6 @@
     "identification_document_front_file": "xsd:string",
     "identification_document_back_file": "xsd:string",
     "identification_document_selfie_file": "xsd:string",
-    "residential_address_proof_file": "xsd:string",
+    "residential_address_proof_file": "xsd:string"
   }
 }

--- a/verifiable_credential/fractal_id.json-ld
+++ b/verifiable_credential/fractal_id.json-ld
@@ -1,13 +1,31 @@
 {
-  "@context": [
-    {
-      "@version": 1.1,
-      "@protected": true,
-      "xsd": "http://www.w3.org/2001/XMLSchema#",
-      "level": {
-        "@id": "level",
-        "@type": "xsd:string"
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "aux": "https://raw.githubusercontent.com/trustfractal/claim-schemas/master/aux.xml",
+    "level": "xsd:string",
+    "emails": "xsd:string",
+    "phones": "xsd:string",
+    "residential_address": "xsd:string",
+    "residential_address_country": "aux:ISO_3166-1_alpha-2",
+    "residential_address_proof_date_of_expiry": "xsd:date",
+    "date_of_birth": "xsd:date",
+    "full_name": "xsd:string",
+    "identification_document_country": "aux:ISO_3166-1_alpha-2",
+    "identification_document_number": "xsd:string",
+    "identification_document_type": "aux:identification_document_type",
+    "place_of_birth": "xsd:string",
+    "identification_document_date_of_issue": "xsd:date",
+    "identification_document_date_of_expiry": "xsd:date",
+    "wallets": {
+      "@id": "https://raw.githubusercontent.com/trustfractal/claim-schemas/master/verifiable_credential/fractal_id.json-ld#wallets",
+      "@context": {
+        "@protected": true,
+        "address": "xsd:string",
+        "currency": "xsd:string",
+        "verified": "xsd:boolean"
       }
     }
-  ]
+  }
 }

--- a/verifiable_credential/fractal_id.json-ld
+++ b/verifiable_credential/fractal_id.json-ld
@@ -1,0 +1,13 @@
+{
+  "@context": [
+    {
+      "@version": 1.1,
+      "@protected": true,
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "level": {
+        "@id": "level",
+        "@type": "xsd:string"
+      }
+    }
+  ]
+}

--- a/verifiable_credential/fractal_id.json-ld
+++ b/verifiable_credential/fractal_id.json-ld
@@ -19,7 +19,7 @@
     "identification_document_date_of_issue": "xsd:date",
     "identification_document_date_of_expiry": "xsd:date",
     "wallets": {
-      "@id": "https://raw.githubusercontent.com/trustfractal/claim-schemas/master/fractal_id.json-ld#wallets",
+      "@id": "https://raw.githubusercontent.com/trustfractal/claim-schemas/master/verifiable_credential/fractal_id.json-ld#wallets",
       "@context": {
         "@protected": true,
         "address": "xsd:string",


### PR DESCRIPTION
## Ticket

https://app.asana.com/0/1204479969653186/1205201888172227

This adds context for verifiable credentials described [here](https://www.notion.so/fractal/W3C-credential-generation-1de2ce3823f94a17b7ae8fb4b4930fcb)

## How do you know this works?

Manual testing in console with `JSON::LD::API.toRdf` gem, also in https://json-ld.org/playground/
